### PR TITLE
[Sizer] Adding modern styles

### DIFF
--- a/components/SizerBase/src/SizerBase.Events.cs
+++ b/components/SizerBase/src/SizerBase.Events.cs
@@ -117,7 +117,7 @@ public partial class SizerBase
 
         if (IsEnabled)
         {
-            VisualStateManager.GoToState(this, _pointerEntered ? "PointerOver" : "Normal", true);
+            VisualStateManager.GoToState(this, _pointerEntered ? PointerOverState : NormalState, true);
         }
     }
 
@@ -127,7 +127,7 @@ public partial class SizerBase
 
         if (IsEnabled)
         {
-            VisualStateManager.GoToState(this, "Pressed", true);
+            VisualStateManager.GoToState(this, PointerOverState, true);
         }
     }
 
@@ -137,7 +137,7 @@ public partial class SizerBase
 
         if (!_pressed && !_dragging && IsEnabled)
         {
-            VisualStateManager.GoToState(this, "Normal", true);
+            VisualStateManager.GoToState(this, NormalState, true);
         }
     }
 
@@ -147,7 +147,7 @@ public partial class SizerBase
 
         if (!_pressed && !_dragging && IsEnabled)
         {
-            VisualStateManager.GoToState(this, "PointerOver", true);
+            VisualStateManager.GoToState(this, PointerOverState, true);
         }
     }
 
@@ -155,24 +155,24 @@ public partial class SizerBase
     {
         _dragging = false;
         _pressed = false;
-        VisualStateManager.GoToState(this, _pointerEntered ? "PointerOver" : "Normal", true);
+        VisualStateManager.GoToState(this, _pointerEntered ? PointerOverState : NormalState, true);
     }
 
     private void SizerBase_ManipulationStarted(object sender, ManipulationStartedRoutedEventArgs e)
     {
         _dragging = true;
-        VisualStateManager.GoToState(this, "Pressed", true);
+        VisualStateManager.GoToState(this, PressedState, true);
     }
 
     private void SizerBase_IsEnabledChanged(object sender, DependencyPropertyChangedEventArgs e)
     {
         if (!IsEnabled)
         {
-            VisualStateManager.GoToState(this, "Disabled", true);
+            VisualStateManager.GoToState(this, DisabledState, true);
         }
         else
         {
-            VisualStateManager.GoToState(this, _pointerEntered ? "PointerOver" : "Normal", true);
+            VisualStateManager.GoToState(this, _pointerEntered ? PointerOverState : NormalState, true);
         }
     }
 }

--- a/components/SizerBase/src/SizerBase.Properties.cs
+++ b/components/SizerBase/src/SizerBase.Properties.cs
@@ -90,10 +90,28 @@ public partial class SizerBase : Control
     public static readonly DependencyProperty OrientationProperty =
         DependencyProperty.Register(nameof(Orientation), typeof(Orientation), typeof(SizerBase), new PropertyMetadata(Orientation.Vertical, OnOrientationPropertyChanged));
 
+    /// <summary>
+    /// Gets or sets if the indicator is visible. If not visible, only the background and cursor will be shown on MouseOver or Pressed states.
+    /// </summary>
+    public bool IsIndicatorVisible
+    {
+        get { return (bool)GetValue(IsIndicatorVisibleProperty); }
+        set { SetValue(IsIndicatorVisibleProperty, value); }
+    }
+
+    /// <summary>
+    /// Identifies the <see cref="IsIndicatorVisible"/> dependency property.
+    /// </summary>
+    public static readonly DependencyProperty IsIndicatorVisibleProperty =
+        DependencyProperty.Register(nameof(IsIndicatorVisible), typeof(bool), typeof(SizerBase), new PropertyMetadata(true, OnIsIndicatorVisiblePropertyChanged));
+
+
     private static void OnOrientationPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
     {
         if (d is SizerBase gripper)
         {
+            VisualStateManager.GoToState(gripper, gripper.Orientation == Orientation.Vertical ? "Vertical" : "Horizontal", true);
+
             CursorEnum cursorByOrientation = gripper.Orientation == Orientation.Vertical ? CursorEnum.SizeWestEast : CursorEnum.SizeNorthSouth;
 
             // See if there's been a cursor override, otherwise we'll pick
@@ -128,6 +146,13 @@ public partial class SizerBase : Control
                 gripper.ProtectedCursor = InputSystemCursor.Create(cursorValue);
             }
 #endif
+        }
+    }
+    private static void OnIsIndicatorVisiblePropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is SizerBase gripper)
+        {
+            VisualStateManager.GoToState(gripper, gripper.IsIndicatorVisible ? "Visible" : "Collapsed", true);
         }
     }
 }

--- a/components/SizerBase/src/SizerBase.Properties.cs
+++ b/components/SizerBase/src/SizerBase.Properties.cs
@@ -91,26 +91,26 @@ public partial class SizerBase : Control
         DependencyProperty.Register(nameof(Orientation), typeof(Orientation), typeof(SizerBase), new PropertyMetadata(Orientation.Vertical, OnOrientationPropertyChanged));
 
     /// <summary>
-    /// Gets or sets if the indicator is visible. If not visible, only the background and cursor will be shown on MouseOver or Pressed states.
+    /// Gets or sets if the Thumb is visible. If not visible, only the background and cursor will be shown on MouseOver or Pressed states.
     /// </summary>
-    public bool IsIndicatorVisible
+    public bool IsThumbVisible
     {
-        get { return (bool)GetValue(IsIndicatorVisibleProperty); }
-        set { SetValue(IsIndicatorVisibleProperty, value); }
+        get { return (bool)GetValue(IsThumbVisibleProperty); }
+        set { SetValue(IsThumbVisibleProperty, value); }
     }
 
     /// <summary>
-    /// Identifies the <see cref="IsIndicatorVisible"/> dependency property.
+    /// Identifies the <see cref="IsThumbVisible"/> dependency property.
     /// </summary>
-    public static readonly DependencyProperty IsIndicatorVisibleProperty =
-        DependencyProperty.Register(nameof(IsIndicatorVisible), typeof(bool), typeof(SizerBase), new PropertyMetadata(true, OnIsIndicatorVisiblePropertyChanged));
+    public static readonly DependencyProperty IsThumbVisibleProperty =
+        DependencyProperty.Register(nameof(IsThumbVisible), typeof(bool), typeof(SizerBase), new PropertyMetadata(true, OnIsThumbVisiblePropertyChanged));
 
 
     private static void OnOrientationPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
     {
         if (d is SizerBase gripper)
         {
-            VisualStateManager.GoToState(gripper, gripper.Orientation == Orientation.Vertical ? "Vertical" : "Horizontal", true);
+            VisualStateManager.GoToState(gripper, gripper.Orientation == Orientation.Vertical ? VerticalState : HorizontalState, true);
 
             CursorEnum cursorByOrientation = gripper.Orientation == Orientation.Vertical ? CursorEnum.SizeWestEast : CursorEnum.SizeNorthSouth;
 
@@ -148,11 +148,11 @@ public partial class SizerBase : Control
 #endif
         }
     }
-    private static void OnIsIndicatorVisiblePropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    private static void OnIsThumbVisiblePropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
     {
         if (d is SizerBase gripper)
         {
-            VisualStateManager.GoToState(gripper, gripper.IsIndicatorVisible ? "Visible" : "Collapsed", true);
+            VisualStateManager.GoToState(gripper, gripper.IsThumbVisible ? VisibleState : CollapsedState, true);
         }
     }
 }

--- a/components/SizerBase/src/SizerBase.cs
+++ b/components/SizerBase/src/SizerBase.cs
@@ -9,8 +9,28 @@ namespace CommunityToolkit.Labs.WinUI;
 /// <summary>
 /// Base class for splitting/resizing type controls like <see cref="GridSplitter"/> and <see cref="ContentSizer"/>. Acts similar to an enlarged <see cref="Windows.UI.Xaml.Controls.Primitives.Thumb"/> type control, but with keyboard support. Subclasses should override the various abstract methods here to implement their behavior.
 /// </summary>
+
+[TemplateVisualState(Name = NormalState, GroupName = CommonStates)]
+[TemplateVisualState(Name = PointerOverState, GroupName = CommonStates)]
+[TemplateVisualState(Name = PressedState, GroupName = CommonStates)]
+[TemplateVisualState(Name = DisabledState, GroupName = CommonStates)]
+[TemplateVisualState(Name = HorizontalState, GroupName = ThumbVisibilityStates)]
+[TemplateVisualState(Name = VerticalState, GroupName = ThumbVisibilityStates)]
+[TemplateVisualState(Name = VisibleState, GroupName = ThumbVisibilityStates)]
+[TemplateVisualState(Name = CollapsedState, GroupName = ThumbVisibilityStates)]
 public abstract partial class SizerBase : Control
 {
+    internal const string CommonStates = "CommonStates";
+    internal const string NormalState = "Normal";
+    internal const string PointerOverState = "PointerOver";
+    internal const string PressedState = "Pressed";
+    internal const string DisabledState = "Disabled";
+    internal const string OrientationStates = "OrientationStates";
+    internal const string HorizontalState = "Horizontal";
+    internal const string VerticalState = "Vertical";
+    internal const string ThumbVisibilityStates = "ThumbVisibilityStates";
+    internal const string VisibleState = "Visible";
+    internal const string CollapsedState = "Collapsed";
     /// <summary>
     /// Called when the control has been initialized.
     /// </summary>
@@ -120,8 +140,8 @@ public abstract partial class SizerBase : Control
         // Ensure we have the proper cursor value setup, as we can only set now for WinUI 3
         OnOrientationPropertyChanged(this, null!);
 
-        // Ensure we set the indicator visiblity
-        OnIsIndicatorVisiblePropertyChanged(this, null!);
+        // Ensure we set the Thumb visiblity
+        OnIsThumbVisiblePropertyChanged(this, null!);
     }
 
     private void SizerBase_Loaded(object sender, RoutedEventArgs e)

--- a/components/SizerBase/src/SizerBase.cs
+++ b/components/SizerBase/src/SizerBase.cs
@@ -119,6 +119,9 @@ public abstract partial class SizerBase : Control
 #endif
         // Ensure we have the proper cursor value setup, as we can only set now for WinUI 3
         OnOrientationPropertyChanged(this, null!);
+
+        // Ensure we set the indicator visiblity
+        OnIsIndicatorVisiblePropertyChanged(this, null!);
     }
 
     private void SizerBase_Loaded(object sender, RoutedEventArgs e)

--- a/components/SizerBase/src/SizerBase.cs
+++ b/components/SizerBase/src/SizerBase.cs
@@ -14,8 +14,8 @@ namespace CommunityToolkit.Labs.WinUI;
 [TemplateVisualState(Name = PointerOverState, GroupName = CommonStates)]
 [TemplateVisualState(Name = PressedState, GroupName = CommonStates)]
 [TemplateVisualState(Name = DisabledState, GroupName = CommonStates)]
-[TemplateVisualState(Name = HorizontalState, GroupName = ThumbVisibilityStates)]
-[TemplateVisualState(Name = VerticalState, GroupName = ThumbVisibilityStates)]
+[TemplateVisualState(Name = HorizontalState, GroupName = OrientationStates)]
+[TemplateVisualState(Name = VerticalState, GroupName = OrientationStates)]
 [TemplateVisualState(Name = VisibleState, GroupName = ThumbVisibilityStates)]
 [TemplateVisualState(Name = CollapsedState, GroupName = ThumbVisibilityStates)]
 public abstract partial class SizerBase : Control

--- a/components/SizerBase/src/SizerBase.xaml
+++ b/components/SizerBase/src/SizerBase.xaml
@@ -1,4 +1,4 @@
-<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
+﻿<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:controls="using:CommunityToolkit.Labs.WinUI"
@@ -8,29 +8,45 @@
 
     <ResourceDictionary.ThemeDictionaries>
         <ResourceDictionary x:Key="Default">
-            <SolidColorBrush x:Key="GripperBarBackgroundPointerOver"
-                             Color="{ThemeResource SystemBaseLowColor}" />
-            <SolidColorBrush x:Key="GripperBarBackgroundPressedOver"
-                             Color="{ThemeResource SystemBaseHighColor}" />
-            <SolidColorBrush x:Key="GripperBarForeground"
-                             Color="{ThemeResource SystemAltHighColor}" />
+            <StaticResource x:Key="SizerBaseBackground"
+                            ResourceKey="ControlAltFillColorTransparentBrush" />
+            <StaticResource x:Key="SizerBaseBackgroundPointerOver"
+                            ResourceKey="ControlAltFillColorTertiaryBrush" />
+            <StaticResource x:Key="SizerBaseBackgroundPressed"
+                            ResourceKey="ControlAltFillColorQuarternaryBrush" />
+            <StaticResource x:Key="SizerBaseBackgroundDisabled"
+                            ResourceKey="ControlAltFillColorDisabledBrush" />
+            <StaticResource x:Key="SizerBaseForeground"
+                            ResourceKey="ControlStrongFillColorDefaultBrush" />
+        </ResourceDictionary>
+        <ResourceDictionary x:Key="Light">
+            <StaticResource x:Key="SizerBaseBackground"
+                            ResourceKey="ControlAltFillColorTransparentBrush" />
+            <StaticResource x:Key="SizerBaseBackgroundPointerOver"
+                            ResourceKey="ControlAltFillColorTertiaryBrush" />
+            <StaticResource x:Key="SizerBaseBackgroundPressed"
+                            ResourceKey="ControlAltFillColorQuarternaryBrush" />
+            <StaticResource x:Key="SizerBaseBackgroundDisabled"
+                            ResourceKey="ControlAltFillColorDisabledBrush" />
+            <StaticResource x:Key="SizerBaseForeground"
+                            ResourceKey="ControlStrongFillColorDefaultBrush" />
         </ResourceDictionary>
         <ResourceDictionary x:Key="HighContrast">
-            <SolidColorBrush x:Key="GripperBarBackgroundPointerOver"
-                             Color="{ThemeResource SystemColorHighlightColor}" />
-            <SolidColorBrush x:Key="GripperBarBackgroundPressedOver"
-                             Color="{ThemeResource SystemColorHighlightColor}" />
-            <SolidColorBrush x:Key="GripperBarForeground"
-                             Color="{ThemeResource SystemAltHighColor}" />
+            <StaticResource x:Key="SizerBaseBackground"
+                            ResourceKey="ControlAltFillColorTransparentBrush" />
+            <StaticResource x:Key="SizerBaseBackgroundPointerOver"
+                            ResourceKey="SystemColorHighlightTextColorBrush" />
+            <StaticResource x:Key="SizerBaseBackgroundPressed"
+                            ResourceKey="SystemColorHighlightColorBrush" />
+            <StaticResource x:Key="SizerBaseBackgroundDisabled"
+                            ResourceKey="SystemColorWindowColorBrush" />
+            <StaticResource x:Key="SizerBaseForeground"
+                            ResourceKey="SystemColorButtonTextColorBrush" />
         </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>
-
-    <local:OrientationToObjectConverter x:Key="OrientationToGlyphConverter"
-                                        HorizontalValue="&#xE76F;"
-                                        VerticalValue="&#xE784;" />
-
-    <StaticResource x:Key="GripperBarFontFamily"
-                    ResourceKey="SymbolThemeFontFamily" />
+    <x:Double x:Key="SizerBaseIndicatorHeight">24</x:Double>
+    <x:Double x:Key="SizerBaseIndicatorWidth">4</x:Double>
+    <x:Double x:Key="SizerBaseIndicatorRadius">2</x:Double>
 
     <Style TargetType="controls:SizerBase">
         <Setter Property="IsTabStop" Value="True" />
@@ -38,9 +54,10 @@
         <Setter Property="HorizontalAlignment" Value="Stretch" />
         <Setter Property="VerticalAlignment" Value="Stretch" />
         <Setter Property="IsFocusEngagementEnabled" Value="True" />
-        <Setter Property="MinWidth" Value="16" />
-        <Setter Property="MinHeight" Value="16" />
-        <Setter Property="Background" Value="{ThemeResource SystemControlHighlightChromeHighBrush}" />
+        <Setter Property="MinHeight" Value="8" />
+        <Setter Property="MinWidth" Value="12" />
+        <Setter Property="Foreground" Value="{ThemeResource SizerBaseForeground}" />
+        <Setter Property="Background" Value="{ThemeResource SizerBaseBackground}" />
         <Setter Property="HorizontalContentAlignment" Value="Center" />
         <Setter Property="VerticalContentAlignment" Value="Center" />
         <Setter Property="AutomationProperties.Name" Value="ms-resource://CommunityToolkit.Labs.WinUI.SizerBase/CommunityToolkit.Labs.WinUI.SizerBase/Resources/WCT_SizerBase_AutomationName" />
@@ -49,33 +66,58 @@
             <Setter.Value>
                 <ControlTemplate TargetType="controls:SizerBase">
                     <Grid x:Name="RootGrid"
-                          Background="{TemplateBinding Background}">
-
+                          Background="{TemplateBinding Background}"
+                          BorderBrush="{TemplateBinding BorderBrush}"
+                          BorderThickness="{TemplateBinding BorderThickness}">
+                        <Grid.BackgroundTransition>
+                            <BrushTransition Duration="0:0:0.083" />
+                        </Grid.BackgroundTransition>
                         <!--  Note: These align with Thumb  -->
                         <VisualStateManager.VisualStateGroups>
                             <VisualStateGroup x:Name="CommonStates">
                                 <VisualState x:Name="Normal" />
                                 <VisualState x:Name="PointerOver">
                                     <VisualState.Setters>
-                                        <Setter Target="RootGrid.Background" Value="{ThemeResource GripperBarBackgroundPointerOver}" />
+                                        <Setter Target="RootGrid.Background" Value="{ThemeResource SizerBaseBackgroundPointerOver}" />
                                     </VisualState.Setters>
                                 </VisualState>
                                 <VisualState x:Name="Pressed">
                                     <VisualState.Setters>
-                                        <Setter Target="RootGrid.Background" Value="{ThemeResource GripperBarBackgroundPressedOver}" />
+                                        <Setter Target="RootGrid.Background" Value="{ThemeResource SizerBaseBackgroundPressed}" />
                                     </VisualState.Setters>
                                 </VisualState>
-                                <!--  TODO  -->
-                                <VisualState x:Name="Disabled" />
+                                <VisualState x:Name="Disabled">
+                                    <VisualState.Setters>
+                                        <Setter Target="RootGrid.Background" Value="{ThemeResource SizerBaseBackgroundDisabled}" />
+                                        <Setter Target="PART_Indicator.Opacity" Value="0.45" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                            </VisualStateGroup>
+                            <VisualStateGroup x:Name="OrientationStates">
+                                <VisualState x:Name="Vertical" />
+                                <VisualState x:Name="Horizontal">
+                                    <VisualState.Setters>
+                                        <Setter Target="PART_Indicator.Width" Value="{ThemeResource SizerBaseIndicatorHeight}" />
+                                        <Setter Target="PART_Indicator.Height" Value="{ThemeResource SizerBaseIndicatorWidth}" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                            </VisualStateGroup>
+                            <VisualStateGroup x:Name="IndicatorVisibilityStates">
+                                <VisualState x:Name="Visible" />
+                                <VisualState x:Name="Collapsed">
+                                    <VisualState.Setters>
+                                        <Setter Target="PART_Indicator.Visibility" Value="Collapsed" />
+                                    </VisualState.Setters>
+                                </VisualState>
                             </VisualStateGroup>
                         </VisualStateManager.VisualStateGroups>
 
-                        <TextBlock HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                   VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                   win:AutomationProperties.AccessibilityView="Raw"
-                                   FontFamily="{ThemeResource GripperBarFontFamily}"
-                                   Foreground="{ThemeResource GripperBarForeground}"
-                                   Text="{Binding Orientation, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource OrientationToGlyphConverter}}" />
+                        <Rectangle x:Name="PART_Indicator"
+                                   Width="{ThemeResource SizerBaseIndicatorWidth}"
+                                   Height="{ThemeResource SizerBaseIndicatorHeight}"
+                                   Fill="{TemplateBinding Foreground}"
+                                   RadiusX="2"
+                                   RadiusY="2" />
                     </Grid>
                 </ControlTemplate>
             </Setter.Value>

--- a/components/SizerBase/src/SizerBase.xaml
+++ b/components/SizerBase/src/SizerBase.xaml
@@ -1,10 +1,7 @@
 ﻿<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:controls="using:CommunityToolkit.Labs.WinUI"
-                    xmlns:local="using:CommunityToolkit.Labs.WinUI.SizerBaseLocal"
-                    xmlns:ui="using:Microsoft.Toolkit.Uwp.UI"
-                    xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+                    xmlns:controls="using:CommunityToolkit.Labs.WinUI">
 
     <ResourceDictionary.ThemeDictionaries>
         <ResourceDictionary x:Key="Default">
@@ -44,9 +41,10 @@
                             ResourceKey="SystemColorButtonTextColorBrush" />
         </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>
-    <x:Double x:Key="SizerBaseIndicatorHeight">24</x:Double>
-    <x:Double x:Key="SizerBaseIndicatorWidth">4</x:Double>
-    <x:Double x:Key="SizerBaseIndicatorRadius">2</x:Double>
+    <x:Double x:Key="SizerBaseThumbHeight">24</x:Double>
+    <x:Double x:Key="SizerBaseThumbWidth">4</x:Double>
+    <x:Double x:Key="SizerBaseThumbRadius">2</x:Double>
+    <Thickness x:Key="SizerBaseThumbMargin">4</Thickness>
 
     <Style TargetType="controls:SizerBase">
         <Setter Property="IsTabStop" Value="True" />
@@ -55,7 +53,7 @@
         <Setter Property="VerticalAlignment" Value="Stretch" />
         <Setter Property="IsFocusEngagementEnabled" Value="True" />
         <Setter Property="MinHeight" Value="8" />
-        <Setter Property="MinWidth" Value="12" />
+        <Setter Property="MinWidth" Value="8" />
         <Setter Property="Foreground" Value="{ThemeResource SizerBaseForeground}" />
         <Setter Property="Background" Value="{ThemeResource SizerBaseBackground}" />
         <Setter Property="HorizontalContentAlignment" Value="Center" />
@@ -72,7 +70,6 @@
                         <Grid.BackgroundTransition>
                             <BrushTransition Duration="0:0:0.083" />
                         </Grid.BackgroundTransition>
-                        <!--  Note: These align with Thumb  -->
                         <VisualStateManager.VisualStateGroups>
                             <VisualStateGroup x:Name="CommonStates">
                                 <VisualState x:Name="Normal" />
@@ -89,7 +86,7 @@
                                 <VisualState x:Name="Disabled">
                                     <VisualState.Setters>
                                         <Setter Target="RootGrid.Background" Value="{ThemeResource SizerBaseBackgroundDisabled}" />
-                                        <Setter Target="PART_Indicator.Opacity" Value="0.45" />
+                                        <Setter Target="PART_Thumb.Opacity" Value="0.45" />
                                     </VisualState.Setters>
                                 </VisualState>
                             </VisualStateGroup>
@@ -97,27 +94,28 @@
                                 <VisualState x:Name="Vertical" />
                                 <VisualState x:Name="Horizontal">
                                     <VisualState.Setters>
-                                        <Setter Target="PART_Indicator.Width" Value="{ThemeResource SizerBaseIndicatorHeight}" />
-                                        <Setter Target="PART_Indicator.Height" Value="{ThemeResource SizerBaseIndicatorWidth}" />
+                                        <Setter Target="PART_Thumb.Width" Value="{ThemeResource SizerBaseThumbHeight}" />
+                                        <Setter Target="PART_Thumb.Height" Value="{ThemeResource SizerBaseThumbWidth}" />
                                     </VisualState.Setters>
                                 </VisualState>
                             </VisualStateGroup>
-                            <VisualStateGroup x:Name="IndicatorVisibilityStates">
+                            <VisualStateGroup x:Name="ThumbVisibilityStates">
                                 <VisualState x:Name="Visible" />
                                 <VisualState x:Name="Collapsed">
                                     <VisualState.Setters>
-                                        <Setter Target="PART_Indicator.Visibility" Value="Collapsed" />
+                                        <Setter Target="PART_Thumb.Visibility" Value="Collapsed" />
                                     </VisualState.Setters>
                                 </VisualState>
                             </VisualStateGroup>
                         </VisualStateManager.VisualStateGroups>
 
-                        <Rectangle x:Name="PART_Indicator"
-                                   Width="{ThemeResource SizerBaseIndicatorWidth}"
-                                   Height="{ThemeResource SizerBaseIndicatorHeight}"
+                        <Rectangle x:Name="PART_Thumb"
+                                   Width="{ThemeResource SizerBaseThumbWidth}"
+                                   Height="{ThemeResource SizerBaseThumbHeight}"
+                                   Margin="{ThemeResource SizerBaseThumbMargin}"
                                    Fill="{TemplateBinding Foreground}"
-                                   RadiusX="2"
-                                   RadiusY="2" />
+                                   RadiusX="{ThemeResource SizerBaseThumbRadius}"
+                                   RadiusY="{ThemeResource SizerBaseThumbRadius}" />
                     </Grid>
                 </ControlTemplate>
             </Setter.Value>


### PR DESCRIPTION
@michael-hawker This PR introduces a W11 modern visual style for the SizerBase based on recommendations from the design team. By default (in rest state) it only shows the indicator with a transparent background.

For specific use cases developers can hide this indicator by setting `IsIndicatorVisible` to `false`.

Let me know if you agree and if this makes sense. Might be better naming for this?

![DragModern](https://user-images.githubusercontent.com/9866362/232426746-9b4e5812-d0c7-4775-979b-83e50cd4957a.gif)

`IsIndicatorVisible` set to `false`
![DragModern2](https://user-images.githubusercontent.com/9866362/232428410-74817956-34ac-4cda-9ffb-d87d1296515c.gif)
